### PR TITLE
fix factory tests so they don't break when new items are registered

### DIFF
--- a/imapautofiler/tests/base.py
+++ b/imapautofiler/tests/base.py
@@ -101,3 +101,15 @@ class TestCase(testtools.TestCase):
                 construct_message(RECENT_MESSAGE)
             )
         return self._recent_msg
+
+
+def pytest_generate_tests(metafunc):
+    # from https://docs.pytest.org/en/latest/example/parametrize.html#a-quick-port-of-testscenarios  # noqa
+    idlist = []
+    argvalues = []
+    for scenario in metafunc.cls.scenarios:
+        idlist.append(scenario[0])
+        items = scenario[1].items()
+        argnames = [x[0] for x in items]
+        argvalues.append(([x[1] for x in items]))
+    metafunc.parametrize(argnames, argvalues, ids=idlist, scope="class")

--- a/imapautofiler/tests/test_actions.py
+++ b/imapautofiler/tests/test_actions.py
@@ -15,6 +15,24 @@ import unittest.mock as mock
 
 from imapautofiler import actions
 from imapautofiler.tests import base
+from imapautofiler.tests.base import pytest_generate_tests  # noqa
+
+
+class TestRegisteredFactories(object):
+    _names = [
+        'move',
+        'sort',
+        'sort-mailing-list',
+        'trash',
+        'delete',
+    ]
+    scenarios = [
+        (name, {'name': name})
+        for name in _names
+    ]
+
+    def test_known(self, name):
+        assert name in actions._lookup_table
 
 
 class TestFactory(unittest.TestCase):
@@ -31,20 +49,6 @@ class TestFactory(unittest.TestCase):
             lt['move'] = mock.Mock()
             actions.factory({'name': 'move'}, {})
             lt['move'].assert_called_with({'name': 'move'}, {})
-
-    def test_known(self):
-        expected = [
-            'move',
-            'sort',
-            'sort-mailing-list',
-            'trash',
-            'delete',
-        ]
-        expected.sort()
-        self.assertEqual(
-            expected,
-            list(sorted(actions._lookup_table.keys())),
-        )
 
 
 class TestMove(base.TestCase):

--- a/imapautofiler/tests/test_rules.py
+++ b/imapautofiler/tests/test_rules.py
@@ -15,6 +15,26 @@ import unittest.mock as mock
 
 from imapautofiler import rules
 from imapautofiler.tests import base
+from imapautofiler.tests.base import pytest_generate_tests  # noqa
+
+
+class TestRegisteredFactories(object):
+    _names = [
+        'or',
+        'and',
+        'recipient',
+        'time-limit',
+        'headers',
+        'header-exists',
+        'is-mailing-list',
+    ]
+    scenarios = [
+        (name, {'name': name})
+        for name in _names
+    ]
+
+    def test_known(self, name):
+        assert name in rules._lookup_table
 
 
 class TestFactory(unittest.TestCase):
@@ -31,22 +51,6 @@ class TestFactory(unittest.TestCase):
             lt['or'] = mock.Mock()
             rules.factory({'or': {}}, {})
             lt['or'].assert_called_with({'or': {}}, {})
-
-    def test_known(self):
-        expected = [
-            'or',
-            'and',
-            'recipient',
-            'time-limit',
-            'headers',
-            'header-exists',
-            'is-mailing-list',
-        ]
-        expected.sort()
-        self.assertEqual(
-            expected,
-            list(sorted(rules._lookup_table.keys())),
-        )
 
 
 class TestOr(base.TestCase):


### PR DESCRIPTION
Fix the factory tests for rules and actions so that they don't break
if we add new items. They test a static list of registered names now,
but test each one separately and don't require the list of registered
names to match exactly the values being tested, so we can have extra
items registered.

Closes bug #24