### PR TITLE
Separate config/args related issue from other errors

### DIFF
--- a/imapautofiler/app.py
+++ b/imapautofiler/app.py
@@ -154,18 +154,19 @@ def main(args=None):
 
     try:
         cfg = config.get_config(args.config_file)
-        conn = client.open_connection(cfg)
-        try:
-            if args.list_mailboxes:
-                list_mailboxes(cfg, args.debug, conn)
-            else:
-                process_rules(cfg, args.debug, conn, args.dry_run)
-        finally:
-            conn.close()
     except Exception as err:
-        if args.debug:
-            raise
         parser.error(err)
+        return -1
+
+    conn = client.open_connection(cfg)
+    try:
+        if args.list_mailboxes:
+            list_mailboxes(cfg, args.debug, conn)
+        else:
+            process_rules(cfg, args.debug, conn, args.dry_run)
+    finally:
+        conn.close()
+
     return 0
 
 


### PR DESCRIPTION
When a random error happens during the execution of the program,
dispalying a traceback is probably the most useful thing the application
can do.